### PR TITLE
Repair quicklinks widget under ELGG 1.8

### DIFF
--- a/lib/hooks.php
+++ b/lib/hooks.php
@@ -91,16 +91,7 @@ function quicklinks_prepare_quicklinks_menu_hook($hook, $type, $returnvalue, $pa
 		
 	$display_limit = (int) elgg_extract("display_limit", $params, 0);
 	if ($display_limit > 0 && elgg_in_context("widgets")) {
-		
-		if (!isset($returnvalue["default"])) {
-			return $returnvalue;
-		}
-		
-		foreach ($returnvalue["default"] as $index => $item) {
-			if ($index >= $display_limit) {
-				$item->addItemClass("hidden");
-			}
-		}
+		$returnvalue["default"] = array_slice($returnvalue["default"], 0, $display_limit);
 	}
 	
 	return $returnvalue;

--- a/views/default/widgets/quicklinks/edit.php
+++ b/views/default/widgets/quicklinks/edit.php
@@ -12,7 +12,7 @@ if ($num_display < 1) {
 
 echo "<div>";
 echo "<label>" . elgg_echo("widget:numbertodisplay") . "</label>";
-echo elgg_view("input/select", array(
+echo elgg_view("input/dropdown", array(
 	"name" => "params[num_display]", 
 	"value" => $num_display, 
 	"options" => range(1,10), 


### PR DESCRIPTION
The 1.8 code contained some 1.8+ code. Therefore some problems occurred. This PR fixes these compatibility issues. The current code results in an unusable dashboard, see image attached.

![image](https://cloud.githubusercontent.com/assets/5213690/8408720/a82416c8-1e72-11e5-8ac7-1230d54d32a0.png).

Chose for array_slice to make the code more readable.
